### PR TITLE
Implement true streaming responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ _version.py
 
 # codspeed
 .codspeed/
+
+# llm scratchpad
+llm/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+Put any markdown files generated during coding sessions in llm/

--- a/src/httpx_pycurl/curl.py
+++ b/src/httpx_pycurl/curl.py
@@ -25,15 +25,12 @@ class AsyncCurl:
     pycurl.error on failure.
     """
 
-    def __init__(
-        self, loop: asyncio.AbstractEventLoop | None = None, max_connections: int = 100
-    ):
+    def __init__(self, loop: asyncio.AbstractEventLoop | None = None):
         """Initialize AsyncCurl.
 
         Args:
             loop: Optional event loop. If None, detected from get_running_loop().
                   AsyncCurl is one-time-use and initializes multi/loop eagerly.
-            max_connections: Maximum total connections for the multi handle.
 
         Raises:
             RuntimeError: If no event loop is available and none provided.
@@ -52,8 +49,6 @@ class AsyncCurl:
 
         # Create multi handle immediately
         self._multi = pycurl.CurlMulti()
-        if hasattr(pycurl, "M_MAX_TOTAL_CONNECTIONS"):
-            self._multi.setopt(pycurl.M_MAX_TOTAL_CONNECTIONS, max_connections)
         self._multi.setopt(pycurl.M_SOCKETFUNCTION, self._socket_callback)
         self._multi.setopt(pycurl.M_TIMERFUNCTION, self._timer_callback)
 
@@ -65,6 +60,12 @@ class AsyncCurl:
 
         # Timer management
         self._timer_handle: asyncio.TimerHandle | None = None
+
+    def setopt(self, *args):
+        """
+        Forward options to our CurlMulti() instance.
+        """
+        return self._multi.setopt(*args)
 
     async def perform(self, curl: pycurl.Curl) -> pycurl.Curl:
         """Execute a curl handle to completion.

--- a/src/httpx_pycurl/curl.py
+++ b/src/httpx_pycurl/curl.py
@@ -168,7 +168,26 @@ class AsyncCurl:
 
     def _register_socket(self, fd: int, what: int) -> None:
         """Register socket with event loop based on event mask."""
-        # Always clean up previous registration
+        current_mode = self._socket_watch.get(fd)
+
+        if what == pycurl.POLL_REMOVE:
+            if current_mode is not None:
+                try:
+                    self._loop.remove_reader(fd)
+                except (ValueError, RuntimeError):
+                    pass
+                try:
+                    self._loop.remove_writer(fd)
+                except (ValueError, RuntimeError):
+                    pass
+                self._socket_watch.pop(fd, None)
+            return
+
+        # Skip if mode hasn't changed
+        if current_mode == what:
+            return
+
+        # Clean up previous registration (only necessary if mode changed)
         try:
             self._loop.remove_reader(fd)
         except (ValueError, RuntimeError):
@@ -177,10 +196,6 @@ class AsyncCurl:
             self._loop.remove_writer(fd)
         except (ValueError, RuntimeError):
             pass
-
-        if what == pycurl.POLL_REMOVE:
-            self._socket_watch.pop(fd, None)
-            return
 
         self._socket_watch[fd] = what
 

--- a/src/httpx_pycurl/curl.py
+++ b/src/httpx_pycurl/curl.py
@@ -11,18 +11,32 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import dataclass
 
 import pycurl
 
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class PerformHandle:
+    """Handle to a transfer in progress.
+
+    Allows non-blocking initiation of a transfer with completion
+    tracked via a future that can be awaited later.
+    """
+
+    curl: pycurl.Curl
+    completion_future: asyncio.Future[None]
+
+
 class AsyncCurl:
     """Manages async execution of pycurl Curl handles via CurlMulti.
 
     Takes pre-configured Curl objects and drives them to completion using
-    an asyncio event loop. Returns the handle when successful, raises
-    pycurl.error on failure.
+    an asyncio event loop. Uses a non-blocking perform() API that returns
+    a handle immediately, allowing the caller to decide when to wait for
+    completion.
     """
 
     def __init__(self, loop: asyncio.AbstractEventLoop | None = None):
@@ -61,23 +75,26 @@ class AsyncCurl:
         # Timer management
         self._timer_handle: asyncio.TimerHandle | None = None
 
-    def setopt(self, *args):
+    def setopt(self, option, value) -> None:
         """
         Forward options to our CurlMulti() instance.
         """
-        return self._multi.setopt(*args)
+        return self._multi.setopt(option, value)
 
-    async def perform(self, curl: pycurl.Curl) -> pycurl.Curl:
-        """Execute a curl handle to completion.
+    def perform(self, curl: pycurl.Curl) -> PerformHandle:
+        """Start a transfer without blocking.
+
+        Initiates the transfer and returns a handle immediately. The handle's
+        completion_future can be awaited later to wait for the transfer to complete.
 
         Args:
             curl: Pre-configured pycurl.Curl handle.
 
         Returns:
-            The same curl handle on success.
+            PerformHandle with curl and completion_future.
 
         Raises:
-            pycurl.error: If the transfer fails.
+            RuntimeError: If AsyncCurl is closed.
         """
         if self._closed:
             raise RuntimeError("AsyncCurl is closed")
@@ -86,22 +103,33 @@ class AsyncCurl:
         future: asyncio.Future[None] = self._loop.create_future()
         self._transfers[curl] = future
 
+        # Add to multi handle (this registers socket callbacks)
+        self._multi.add_handle(curl)
+
+        # Trigger initial processing
+        self._drive_socket(pycurl.SOCKET_TIMEOUT, 0)
+
+        # Return handle immediately (non-blocking)
+        return PerformHandle(curl=curl, completion_future=future)
+
+    async def wait_for_completion(self, handle: PerformHandle) -> pycurl.Curl:
+        """Wait for a transfer to complete.
+
+        Args:
+            handle: PerformHandle returned from perform().
+
+        Returns:
+            The curl handle on success.
+
+        Raises:
+            pycurl.error: If the transfer fails.
+        """
         try:
-            # Add to multi handle
-            self._multi.add_handle(curl)
-
-            # Trigger initial processing
-            self._drive_socket(pycurl.SOCKET_TIMEOUT, 0)
-
-            # Wait for completion
-            await future
-
-            # On success, return the handle
-            return curl
-
+            await handle.completion_future
+            return handle.curl
         except Exception:
             # Remove transfer tracking on error
-            self._transfers.pop(curl, None)
+            self._transfers.pop(handle.curl, None)
             # Don't close the handle - let caller decide
             raise
 
@@ -115,13 +143,20 @@ class AsyncCurl:
         self._cleanup_sockets()
 
         if self._multi is not None:
-            # Don't remove handles here - leave them to caller
+            # Remove all handles before closing multi
+            for curl in list(self._transfers.keys()):
+                try:
+                    self._multi.remove_handle(curl)
+                except Exception:
+                    pass
             # Just clean up the multi object
             try:
                 self._multi.close()
             except Exception as e:
                 logger.exception("Error closing CurlMulti: %s", e)
             self._multi = None
+        
+        self._transfers.clear()
 
     async def __aenter__(self) -> AsyncCurl:
         """Async context manager entry."""
@@ -133,9 +168,15 @@ class AsyncCurl:
 
     def _register_socket(self, fd: int, what: int) -> None:
         """Register socket with event loop based on event mask."""
-        # Clean up previous registration
-        self._loop.remove_reader(fd)
-        self._loop.remove_writer(fd)
+        # Always clean up previous registration
+        try:
+            self._loop.remove_reader(fd)
+        except (ValueError, RuntimeError):
+            pass
+        try:
+            self._loop.remove_writer(fd)
+        except (ValueError, RuntimeError):
+            pass
 
         if what == pycurl.POLL_REMOVE:
             self._socket_watch.pop(fd, None)
@@ -148,11 +189,17 @@ class AsyncCurl:
                 self._loop.add_reader(fd, self._on_socket_readable, fd)
             if what in {pycurl.POLL_OUT, pycurl.POLL_INOUT}:
                 self._loop.add_writer(fd, self._on_socket_writable, fd)
-        except OSError as e:
+        except (OSError, ValueError, RuntimeError) as e:
             logger.warning("Failed to register socket %d: %s", fd, e)
             self._socket_watch.pop(fd, None)
-            self._loop.remove_reader(fd)
-            self._loop.remove_writer(fd)
+            try:
+                self._loop.remove_reader(fd)
+            except (ValueError, RuntimeError):
+                pass
+            try:
+                self._loop.remove_writer(fd)
+            except (ValueError, RuntimeError):
+                pass
 
     def _socket_callback(
         self, what: int, fd: int, multi: pycurl.CurlMulti, socketp: object

--- a/src/httpx_pycurl/transport.py
+++ b/src/httpx_pycurl/transport.py
@@ -11,7 +11,7 @@ import certifi
 import httpx
 import pycurl
 
-from .curl import AsyncCurl
+from .curl import AsyncCurl, PerformHandle
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterable, Iterator
@@ -572,119 +572,23 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
                 body_reader=body_reader,
             )
 
-            # Track transfer info
-            future: asyncio.Future[_CurlResponse] = loop.create_future()
-            self._transfers[curl] = _Transfer(request, context, future)
+            # Start transfer (non-blocking, returns immediately)
+            handle = self._curl.perform(curl)
+            self._transfers[curl] = _Transfer(request, context, handle.completion_future)
 
-            curl_response = None
-            perform_error = None
-            early_return = False
+            # Wait for completion
+            await self._curl.wait_for_completion(handle)
+            
+            # Finalize response
+            curl_response = _finalize_curl_response(curl, context)
 
-            try:
-                # Start the perform task (always runs as a task)
-                perform_task = asyncio.create_task(self._curl.perform(curl))
-
-                # If streaming is enabled, we want to return early when headers are ready
-                if async_stream is not None and context.headers_ready is not None:
-                    # Create a task that waits for headers to be ready
-                    headers_wait_task = asyncio.create_task(
-                        context.headers_ready.wait()
-                    )
-
-                    # Wait for either headers to be ready or perform to complete
-                    done, pending = await asyncio.wait(
-                        [perform_task, headers_wait_task],
-                        return_when=asyncio.FIRST_COMPLETED,
-                    )
-
-                    # Check if perform completed with error
-                    perform_error_temp = None
-                    for task in done:
-                        if task is perform_task:
-                            try:
-                                await task
-                            except pycurl.error as error:
-                                code, message = error.args
-                                perform_error_temp = _map_pycurl_error(
-                                    code, str(message), curl
-                                )
-                            break
-
-                    # If we have headers ready and status code, finalize early response
-                    if (
-                        context.headers_complete
-                        and context.status_line is not None
-                        and not perform_task.done()
-                    ):
-                        # Headers completed but perform not done - return early
-                        curl_response = _finalize_curl_response(curl, context)
-                        # Create response
-                        response = httpx.Response(
-                            status_code=curl_response.status_code,
-                            headers=curl_response.headers,
-                            stream=curl_response.body_stream
-                            or _FileStream(curl_response.body_file),
-                            request=request,
-                            extensions={"http_version": curl_response.http_version},
-                        )
-                        # Schedule background cleanup (this will signal end of stream when perform completes)
-                        # Background cleanup handles all cleanup for streaming case
-                        asyncio.create_task(
-                            self._background_perform_cleanup(
-                                curl, perform_task, context, async_stream
-                            )
-                        )
-                        early_return = True
-                        return response
-
-                    # If perform completed (either success or failure), proceed to normal handling
-                    if perform_task.done():
-                        perform_error = perform_error_temp
-                    else:
-                        # Headers not ready and perform not done - this shouldn't happen normally
-                        # but wait for perform to complete
-                        await perform_task
-                else:
-                    # Non-streaming: wait for perform to complete
-                    try:
-                        await perform_task
-                    except pycurl.error as error:
-                        code, message = error.args
-                        perform_error = _map_pycurl_error(code, str(message), curl)
-
-                # Finalize response
-                if curl_response is None:
-                    curl_response = _finalize_curl_response(curl, context)
-
-                # Handle errors for non-streaming responses
-                if perform_error is not None:
-                    if curl_response.status_code == 0:
-                        # No response started, raise immediately
-                        raise perform_error
-                    # For streaming with status code and partial data: error will be queued via background cleanup
-
-                return httpx.Response(
-                    status_code=curl_response.status_code,
-                    headers=curl_response.headers,
-                    stream=curl_response.body_stream
-                    or _FileStream(curl_response.body_file),
-                    request=request,
-                    extensions={"http_version": curl_response.http_version},
-                )
-            except pycurl.error as error:
-                code, message = error.args
-                raise _map_pycurl_error(code, str(message), curl) from error
-            finally:
-                # Clean up transfer tracking and resources
-                # Skip cleanup for early return streaming (handled by _background_perform_cleanup)
-                if not early_return:
-                    self._transfers.pop(curl, None)
-                    # Note: Don't close response_body here - it's still needed by the response stream
-                    # The stream will close it via _FileStream.close() or aclose()
-                    try:
-                        curl.close()
-                    except Exception:
-                        pass
+            return httpx.Response(
+                status_code=curl_response.status_code,
+                headers=curl_response.headers,
+                stream=curl_response.body_stream or _FileStream(curl_response.body_file),
+                request=request,
+                extensions={"http_version": curl_response.http_version},
+            )
         except pycurl.error as error:
             self._transfers.pop(curl, None)
             context.response_body.close()
@@ -694,6 +598,14 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
                 pass
             code, message = error.args
             raise _map_pycurl_error(code, str(message), curl) from error
+        except asyncio.TimeoutError:
+            self._transfers.pop(curl, None)
+            context.response_body.close()
+            try:
+                curl.close()
+            except Exception:
+                pass
+            raise httpx.ConnectTimeout("Transfer timeout")
         except Exception:
             self._transfers.pop(curl, None)
             context.response_body.close()
@@ -708,8 +620,9 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
             return
         self._closed = True
 
-        # Close AsyncCurl
-        await self._curl.aclose()
+        # Close AsyncCurl if it was initialized
+        if self._curl is not None:
+            await self._curl.aclose()
 
         # Clean up any remaining transfers
         for curl, transfer in list(self._transfers.items()):
@@ -719,40 +632,3 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
             except Exception:
                 pass
         self._transfers.clear()
-
-    async def _background_perform_cleanup(
-        self,
-        curl: pycurl.Curl,
-        perform_task: asyncio.Task,
-        context: _TransferContext,
-        async_stream: _AsyncQueueStream | None,
-    ) -> None:
-        """Clean up after perform completes in the background.
-
-        This is used for streaming responses that return early before the
-        full transfer completes. It waits for perform to finish, signals
-        end of stream, and cleans up resources.
-        """
-        try:
-            await perform_task
-        except pycurl.error as error:
-            code, message = error.args
-            perform_error = _map_pycurl_error(code, str(message), curl)
-            # Queue error to be read from stream
-            if async_stream is not None:
-                try:
-                    async_stream._queue.put_nowait(perform_error)
-                except asyncio.QueueFull:
-                    pass
-        finally:
-            # Signal end of stream for streaming responses
-            if async_stream is not None:
-                async_stream.signal_end_of_stream()
-            # Clean up transfer tracking
-            self._transfers.pop(curl, None)
-            # Close response body file
-            context.response_body.close()
-            try:
-                curl.close()
-            except Exception:
-                pass

--- a/src/httpx_pycurl/transport.py
+++ b/src/httpx_pycurl/transport.py
@@ -532,7 +532,9 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
 
         # Lazily initialize AsyncCurl on first request
         if self._curl is None:
-            self._curl = AsyncCurl(loop, max_connections=self._max_connections)
+            self._curl = AsyncCurl(loop)
+            # since curl 7.30.0 (2013):
+            self._curl.setopt(pycurl.M_MAX_TOTAL_CONNECTIONS, self._max_connections)
 
         context = _TransferContext(
             response_body=SpooledTemporaryFile(max_size=1024 * 1024)

--- a/src/httpx_pycurl/transport.py
+++ b/src/httpx_pycurl/transport.py
@@ -542,7 +542,7 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
         # Create async queue stream for streaming response bodies if enabled
         async_stream = _AsyncQueueStream(loop) if self._stream_response else None
         context.async_stream = async_stream
-        
+
         # Create event for signaling when headers are ready
         # This allows returning response early for streaming
         if self._stream_response:
@@ -576,23 +576,25 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
 
             curl_response = None
             perform_error = None
+            early_return = False
 
             try:
+                # Start the perform task (always runs as a task)
+                perform_task = asyncio.create_task(self._curl.perform(curl))
+
                 # If streaming is enabled, we want to return early when headers are ready
-                # Run perform concurrently with waiting for headers
-                early_return = False
                 if async_stream is not None and context.headers_ready is not None:
-                    # Start the perform task
-                    perform_task = asyncio.create_task(self._curl.perform(curl))
                     # Create a task that waits for headers to be ready
-                    headers_wait_task = asyncio.create_task(context.headers_ready.wait())
-                    
+                    headers_wait_task = asyncio.create_task(
+                        context.headers_ready.wait()
+                    )
+
                     # Wait for either headers to be ready or perform to complete
                     done, pending = await asyncio.wait(
                         [perform_task, headers_wait_task],
                         return_when=asyncio.FIRST_COMPLETED,
                     )
-                    
+
                     # Check if perform completed with error
                     perform_error_temp = None
                     for task in done:
@@ -601,27 +603,38 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
                                 await task
                             except pycurl.error as error:
                                 code, message = error.args
-                                perform_error_temp = _map_pycurl_error(code, str(message), curl)
+                                perform_error_temp = _map_pycurl_error(
+                                    code, str(message), curl
+                                )
                             break
-                    
+
                     # If we have headers ready and status code, finalize early response
-                    if context.headers_complete and context.status_line is not None and not perform_task.done():
+                    if (
+                        context.headers_complete
+                        and context.status_line is not None
+                        and not perform_task.done()
+                    ):
                         # Headers completed but perform not done - return early
                         curl_response = _finalize_curl_response(curl, context)
                         # Create response
                         response = httpx.Response(
                             status_code=curl_response.status_code,
                             headers=curl_response.headers,
-                            stream=curl_response.body_stream or _FileStream(curl_response.body_file),
+                            stream=curl_response.body_stream
+                            or _FileStream(curl_response.body_file),
                             request=request,
                             extensions={"http_version": curl_response.http_version},
                         )
-                        # Mark that we're doing early return so cleanup happens in background
-                        early_return = True
                         # Schedule background cleanup (this will signal end of stream when perform completes)
-                        asyncio.create_task(self._background_perform_cleanup(curl, perform_task, context, async_stream))
+                        # Background cleanup handles all cleanup for streaming case
+                        asyncio.create_task(
+                            self._background_perform_cleanup(
+                                curl, perform_task, context, async_stream
+                            )
+                        )
+                        early_return = True
                         return response
-                    
+
                     # If perform completed (either success or failure), proceed to normal handling
                     if perform_task.done():
                         perform_error = perform_error_temp
@@ -630,69 +643,62 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
                         # but wait for perform to complete
                         await perform_task
                 else:
-                    # Normal path: wait for perform to complete
-                    await self._curl.perform(curl)
+                    # Non-streaming: wait for perform to complete
+                    try:
+                        await perform_task
+                    except pycurl.error as error:
+                        code, message = error.args
+                        perform_error = _map_pycurl_error(code, str(message), curl)
+
+                # Finalize response
+                if curl_response is None:
+                    curl_response = _finalize_curl_response(curl, context)
+
+                # Handle errors for non-streaming responses
+                if perform_error is not None:
+                    if curl_response.status_code == 0:
+                        # No response started, raise immediately
+                        raise perform_error
+                    # For streaming with status code and partial data: error will be queued via background cleanup
+
+                return httpx.Response(
+                    status_code=curl_response.status_code,
+                    headers=curl_response.headers,
+                    stream=curl_response.body_stream
+                    or _FileStream(curl_response.body_file),
+                    request=request,
+                    extensions={"http_version": curl_response.http_version},
+                )
             except pycurl.error as error:
                 code, message = error.args
-                # Store the error to signal it later via the stream
-                perform_error = _map_pycurl_error(code, str(message), curl)
+                raise _map_pycurl_error(code, str(message), curl) from error
             finally:
-                # Finalize response and clean up
-                try:
-                    if curl_response is None:  # Only finalize if not already done
-                        curl_response = _finalize_curl_response(curl, context)
-                    # Signal end of stream if using async streaming
-                    # But NOT if we did early return (background task handles it)
-                    if async_stream is not None and not early_return:
-                        if perform_error is not None:
-                            # If transfer failed, queue the error before the sentinel
-                            try:
-                                async_stream._queue.put_nowait(perform_error)
-                            except asyncio.QueueFull:
-                                pass
-                        # Always signal end of stream
-                        async_stream.signal_end_of_stream()
-                except Exception:
-                    context.response_body.close()
-                    raise
-                finally:
-                    # Only pop from transfers if not doing early return
-                    if not early_return:
-                        self._transfers.pop(curl, None)
-
-            # If perform() failed but we got a response (partial data received),
-            # we should still return the response and let the stream signal the error
-            if perform_error is not None:
-                if (
-                    async_stream is None
-                    or curl_response is None
-                    or curl_response.status_code == 0
-                ):
-                    # For non-streaming, no response, or error before response started: raise immediately
-                    curl.close()
-                    raise perform_error
-                # For streaming with status code and partial data: error was already queued, continue
-
-            curl.close()
-
-            return httpx.Response(
-                status_code=curl_response.status_code,
-                headers=curl_response.headers,
-                stream=curl_response.body_stream
-                or _FileStream(curl_response.body_file),
-                request=request,
-                extensions={"http_version": curl_response.http_version},
-            )
+                # Clean up transfer tracking and resources
+                # Skip cleanup for early return streaming (handled by _background_perform_cleanup)
+                if not early_return:
+                    self._transfers.pop(curl, None)
+                    # Note: Don't close response_body here - it's still needed by the response stream
+                    # The stream will close it via _FileStream.close() or aclose()
+                    try:
+                        curl.close()
+                    except Exception:
+                        pass
         except pycurl.error as error:
             self._transfers.pop(curl, None)
             context.response_body.close()
-            curl.close()
+            try:
+                curl.close()
+            except Exception:
+                pass
             code, message = error.args
             raise _map_pycurl_error(code, str(message), curl) from error
         except Exception:
             self._transfers.pop(curl, None)
             context.response_body.close()
-            curl.close()
+            try:
+                curl.close()
+            except Exception:
+                pass
             raise
 
     async def aclose(self):
@@ -711,7 +717,7 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
             except Exception:
                 pass
         self._transfers.clear()
-    
+
     async def _background_perform_cleanup(
         self,
         curl: pycurl.Curl,
@@ -719,7 +725,12 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
         context: _TransferContext,
         async_stream: _AsyncQueueStream | None,
     ) -> None:
-        """Clean up after perform completes in the background."""
+        """Clean up after perform completes in the background.
+
+        This is used for streaming responses that return early before the
+        full transfer completes. It waits for perform to finish, signals
+        end of stream, and cleans up resources.
+        """
         try:
             await perform_task
         except pycurl.error as error:
@@ -732,11 +743,13 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
                 except asyncio.QueueFull:
                     pass
         finally:
-            # Signal end of stream
+            # Signal end of stream for streaming responses
             if async_stream is not None:
                 async_stream.signal_end_of_stream()
             # Clean up transfer tracking
             self._transfers.pop(curl, None)
+            # Close response body file
+            context.response_body.close()
             try:
                 curl.close()
             except Exception:

--- a/src/httpx_pycurl/transport.py
+++ b/src/httpx_pycurl/transport.py
@@ -576,19 +576,77 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
             handle = self._curl.perform(curl)
             self._transfers[curl] = _Transfer(request, context, handle.completion_future)
 
-            # Wait for completion
-            await self._curl.wait_for_completion(handle)
-            
-            # Finalize response
+            # --- Streaming path: return as soon as headers arrive ---
+            if async_stream is not None:
+                # Race the headers-ready event against the raw completion future.
+                # We do NOT wrap the completion future in wait_for_completion here
+                # because cancelling that coroutine would discard the future's result.
+                headers_task = asyncio.ensure_future(context.headers_ready.wait())
+                await asyncio.wait(
+                    [headers_task, handle.completion_future],
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                # Always cancel / clean up the headers_task; it's ephemeral.
+                headers_task.cancel()
+                try:
+                    await headers_task
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+                if handle.completion_future.done():
+                    # Transfer finished before (or at same time as) headers.
+                    self._transfers.pop(curl, None)
+                    perform_error: httpx.TransportError | None = None
+                    try:
+                        handle.completion_future.result()
+                    except pycurl.error as error:
+                        code, message = error.args
+                        perform_error = _map_pycurl_error(code, str(message), curl)
+                        async_stream._queue.put_nowait(perform_error)
+                    async_stream.signal_end_of_stream()
+
+                    curl_response = _finalize_curl_response(curl, context)
+                    if perform_error is not None and curl_response.status_code == 0:
+                        raise perform_error
+                else:
+                    # Headers ready; transfer still running.
+                    # _finish_streaming takes ownership of the handle.
+                    curl_response = _finalize_curl_response(curl, context)
+                    asyncio.ensure_future(
+                        self._finish_streaming(handle, context, async_stream, curl)
+                    )
+
+                return httpx.Response(
+                    status_code=curl_response.status_code,
+                    headers=curl_response.headers,
+                    stream=curl_response.body_stream or _FileStream(curl_response.body_file),
+                    request=request,
+                    extensions={"http_version": curl_response.http_version},
+                )
+
+            # --- Non-streaming path: buffer everything, then return ---
+            perform_error = None
+            try:
+                await self._curl.wait_for_completion(handle)
+            except pycurl.error as error:
+                code, message = error.args
+                perform_error = _map_pycurl_error(code, str(message), curl)
+            finally:
+                self._transfers.pop(curl, None)
+
             curl_response = _finalize_curl_response(curl, context)
+            if perform_error is not None and curl_response.status_code == 0:
+                raise perform_error
 
             return httpx.Response(
                 status_code=curl_response.status_code,
                 headers=curl_response.headers,
-                stream=curl_response.body_stream or _FileStream(curl_response.body_file),
+                stream=_FileStream(curl_response.body_file),
                 request=request,
                 extensions={"http_version": curl_response.http_version},
             )
+        except httpx.TransportError:
+            raise
         except pycurl.error as error:
             self._transfers.pop(curl, None)
             context.response_body.close()
@@ -598,14 +656,6 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
                 pass
             code, message = error.args
             raise _map_pycurl_error(code, str(message), curl) from error
-        except asyncio.TimeoutError:
-            self._transfers.pop(curl, None)
-            context.response_body.close()
-            try:
-                curl.close()
-            except Exception:
-                pass
-            raise httpx.ConnectTimeout("Transfer timeout")
         except Exception:
             self._transfers.pop(curl, None)
             context.response_body.close()
@@ -614,6 +664,33 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
             except Exception:
                 pass
             raise
+
+    async def _finish_streaming(
+        self,
+        handle: PerformHandle,
+        context: _TransferContext,
+        async_stream: _AsyncQueueStream,
+        curl: pycurl.Curl,
+    ) -> None:
+        """Background coroutine that owns a transfer after early header return.
+
+        Waits for the transfer to finish, then signals end-of-stream so the
+        consumer of async_stream unblocks. Handles errors by queuing them.
+        """
+        try:
+            await self._curl.wait_for_completion(handle)
+        except pycurl.error as error:
+            code, message = error.args
+            perform_error = _map_pycurl_error(code, str(message), curl)
+            async_stream._queue.put_nowait(perform_error)
+        finally:
+            async_stream.signal_end_of_stream()
+            self._transfers.pop(curl, None)
+            context.response_body.close()
+            try:
+                curl.close()
+            except Exception:
+                pass
 
     async def aclose(self):
         if self._closed:

--- a/src/httpx_pycurl/transport.py
+++ b/src/httpx_pycurl/transport.py
@@ -38,6 +38,8 @@ class _TransferContext:
     status_line: bytes | None = None
     response_headers: list[tuple[bytes, bytes]] = field(default_factory=list)
     async_stream: _AsyncQueueStream | None = None
+    headers_ready: asyncio.Event | None = None
+    headers_complete: bool = False
 
 
 @dataclass
@@ -295,10 +297,16 @@ def _configure_curl(
     def header_callback(chunk: bytes) -> int:
         line = chunk.rstrip(b"\r\n")
         if not line:
+            # Blank line indicates end of headers
+            if context.status_line is not None and not context.headers_complete:
+                context.headers_complete = True
+                if context.headers_ready is not None:
+                    context.headers_ready.set()
             return len(chunk)
         if line.startswith(b"HTTP/"):
             context.status_line = line
             context.response_headers.clear()
+            context.headers_complete = False
             return len(chunk)
         key, sep, value = line.partition(b":")
         if sep:
@@ -534,6 +542,11 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
         # Create async queue stream for streaming response bodies if enabled
         async_stream = _AsyncQueueStream(loop) if self._stream_response else None
         context.async_stream = async_stream
+        
+        # Create event for signaling when headers are ready
+        # This allows returning response early for streaming
+        if self._stream_response:
+            context.headers_ready = asyncio.Event()
 
         try:
             # Pre-consume async request streams
@@ -565,8 +578,60 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
             perform_error = None
 
             try:
-                # Perform the transfer via AsyncCurl
-                await self._curl.perform(curl)
+                # If streaming is enabled, we want to return early when headers are ready
+                # Run perform concurrently with waiting for headers
+                early_return = False
+                if async_stream is not None and context.headers_ready is not None:
+                    # Start the perform task
+                    perform_task = asyncio.create_task(self._curl.perform(curl))
+                    # Create a task that waits for headers to be ready
+                    headers_wait_task = asyncio.create_task(context.headers_ready.wait())
+                    
+                    # Wait for either headers to be ready or perform to complete
+                    done, pending = await asyncio.wait(
+                        [perform_task, headers_wait_task],
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    
+                    # Check if perform completed with error
+                    perform_error_temp = None
+                    for task in done:
+                        if task is perform_task:
+                            try:
+                                await task
+                            except pycurl.error as error:
+                                code, message = error.args
+                                perform_error_temp = _map_pycurl_error(code, str(message), curl)
+                            break
+                    
+                    # If we have headers ready and status code, finalize early response
+                    if context.headers_complete and context.status_line is not None and not perform_task.done():
+                        # Headers completed but perform not done - return early
+                        curl_response = _finalize_curl_response(curl, context)
+                        # Create response
+                        response = httpx.Response(
+                            status_code=curl_response.status_code,
+                            headers=curl_response.headers,
+                            stream=curl_response.body_stream or _FileStream(curl_response.body_file),
+                            request=request,
+                            extensions={"http_version": curl_response.http_version},
+                        )
+                        # Mark that we're doing early return so cleanup happens in background
+                        early_return = True
+                        # Schedule background cleanup (this will signal end of stream when perform completes)
+                        asyncio.create_task(self._background_perform_cleanup(curl, perform_task, context, async_stream))
+                        return response
+                    
+                    # If perform completed (either success or failure), proceed to normal handling
+                    if perform_task.done():
+                        perform_error = perform_error_temp
+                    else:
+                        # Headers not ready and perform not done - this shouldn't happen normally
+                        # but wait for perform to complete
+                        await perform_task
+                else:
+                    # Normal path: wait for perform to complete
+                    await self._curl.perform(curl)
             except pycurl.error as error:
                 code, message = error.args
                 # Store the error to signal it later via the stream
@@ -574,9 +639,11 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
             finally:
                 # Finalize response and clean up
                 try:
-                    curl_response = _finalize_curl_response(curl, context)
+                    if curl_response is None:  # Only finalize if not already done
+                        curl_response = _finalize_curl_response(curl, context)
                     # Signal end of stream if using async streaming
-                    if async_stream is not None:
+                    # But NOT if we did early return (background task handles it)
+                    if async_stream is not None and not early_return:
                         if perform_error is not None:
                             # If transfer failed, queue the error before the sentinel
                             try:
@@ -589,7 +656,9 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
                     context.response_body.close()
                     raise
                 finally:
-                    self._transfers.pop(curl, None)
+                    # Only pop from transfers if not doing early return
+                    if not early_return:
+                        self._transfers.pop(curl, None)
 
             # If perform() failed but we got a response (partial data received),
             # we should still return the response and let the stream signal the error
@@ -642,3 +711,33 @@ class AsyncPyCurlTransport(httpx.AsyncBaseTransport):
             except Exception:
                 pass
         self._transfers.clear()
+    
+    async def _background_perform_cleanup(
+        self,
+        curl: pycurl.Curl,
+        perform_task: asyncio.Task,
+        context: _TransferContext,
+        async_stream: _AsyncQueueStream | None,
+    ) -> None:
+        """Clean up after perform completes in the background."""
+        try:
+            await perform_task
+        except pycurl.error as error:
+            code, message = error.args
+            perform_error = _map_pycurl_error(code, str(message), curl)
+            # Queue error to be read from stream
+            if async_stream is not None:
+                try:
+                    async_stream._queue.put_nowait(perform_error)
+                except asyncio.QueueFull:
+                    pass
+        finally:
+            # Signal end of stream
+            if async_stream is not None:
+                async_stream.signal_end_of_stream()
+            # Clean up transfer tracking
+            self._transfers.pop(curl, None)
+            try:
+                curl.close()
+            except Exception:
+                pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,10 +118,10 @@ class SlowHandler(BaseHTTPRequestHandler):
                 self.send_header("Content-Type", "text/plain")
                 self.send_header("Content-Length", len(body) * 2)
                 self.end_headers()
-                time.sleep(0.1)
+                time.sleep(0.01)
                 self.wfile.write(body)
                 self.wfile.flush()
-                time.sleep(0.1)
+                time.sleep(0.01)
                 self.wfile.write(body)
                 self.wfile.flush()
             elif self.path == "/short":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,20 @@ class SlowHandler(BaseHTTPRequestHandler):
                 self.send_header("Content-Type", "text/plain")
                 self.end_headers()
                 self.wfile.write(b"Delayed response after 60 seconds\n")
+            elif self.path == "/stream":
+                # Send some headers; wait; send response. To test true
+                # streaming responses.
+                body = b"OK\n"
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain")
+                self.send_header("Content-Length", len(body) * 2)
+                self.end_headers()
+                time.sleep(0.1)
+                self.wfile.write(body)
+                self.wfile.flush()
+                time.sleep(0.1)
+                self.wfile.write(body)
+                self.wfile.flush()
             elif self.path == "/short":
                 self.send_response(200)
                 self.send_header("Content-Type", "text/plain")
@@ -117,7 +131,6 @@ class SlowHandler(BaseHTTPRequestHandler):
                 self.end_headers()
                 self.wfile.write(b"short response\n")
                 self.wfile.flush()
-                # time.sleep(0.1)  # help with race condition getting content vs error?
                 raise TimeoutError("early close from server")
             else:
                 body = b"OK\n"

--- a/tests/test_curl.py
+++ b/tests/test_curl.py
@@ -66,7 +66,7 @@ async def test_asynccurl_perform_when_closed():
 
     handle = pycurl.Curl()
     with pytest.raises(RuntimeError, match="AsyncCurl is closed"):
-        await curl.perform(handle)
+        curl.perform(handle)
 
 
 @pytest.mark.asyncio
@@ -112,7 +112,11 @@ async def test_asynccurl_perform_with_simple_handle():
     handle.setopt(pycurl.TIMEOUT, 2)
 
     try:
-        result = await asyncio.wait_for(curl_obj.perform(handle), timeout=10)
+        # perform() returns immediately with a PerformHandle; wait_for_completion() is awaitable
+        perform_handle = curl_obj.perform(handle)
+        assert perform_handle.curl is handle
+        # Wait for the transfer to complete
+        result = await asyncio.wait_for(curl_obj.wait_for_completion(perform_handle), timeout=10)
         assert result is handle
     finally:
         await curl_obj.aclose()

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -252,3 +252,70 @@ async def test_response_closed_early(regular, short_server):
                     chunks.append(chunk)
 
         assert chunks == [b"short response\n"]
+
+
+@pytest.mark.asyncio
+async def test_streaming_chunk_timing(slow_server):
+    """Test that streaming chunks are received at the expected times.
+    
+    This test verifies that we can:
+    1. Receive the response immediately
+    2. Receive the first chunk about 0.1 seconds later
+    3. Receive the second chunk about 0.1 seconds later
+    
+    This tests whether the transport supports true streaming (returning
+    early from perform()) rather than buffering all data.
+    """
+    url = f"{slow_server}stream"
+    
+    async with httpx.AsyncClient(
+        transport=transport.AsyncPyCurlTransport()
+    ) as client:
+        # Record when we start
+        response_received_time = None
+        chunk_times = []
+        
+        # Start streaming
+        start_time = time.monotonic()
+        async with client.stream("GET", url) as response:
+            # Record when response headers are received
+            response_received_time = time.monotonic() - start_time
+            assert response.status_code == 200
+            
+            # Iterate through chunks and record timing
+            async for chunk in response.aiter_bytes():
+                chunk_time = time.monotonic() - start_time
+                chunk_times.append((chunk_time, chunk))
+        
+        # Verify we got exactly 2 chunks, each containing b"OK\n"
+        assert len(chunk_times) == 2, f"Expected 2 chunks, got {len(chunk_times)}"
+        assert chunk_times[0][1] == b"OK\n", f"First chunk: {chunk_times[0][1]}"
+        assert chunk_times[1][1] == b"OK\n", f"Second chunk: {chunk_times[1][1]}"
+        
+        # Print timing information
+        print(f"\nResponse received after: {response_received_time:.3f}s")
+        print(f"First chunk received after: {chunk_times[0][0]:.3f}s")
+        print(f"Second chunk received after: {chunk_times[1][0]:.3f}s")
+        
+        # Verify timing: chunks should arrive approximately 0.1s apart
+        # with some tolerance for timing variations
+        first_chunk_time = chunk_times[0][0]
+        second_chunk_time = chunk_times[1][0]
+        
+        # First chunk should arrive around 0.1s after response
+        # (server delays 0.1s before sending first chunk)
+        assert (
+            0.05 < first_chunk_time < 0.3
+        ), f"First chunk timing unexpected: {first_chunk_time:.3f}s (expected ~0.1s)"
+        
+        # Second chunk should arrive around 0.2s total
+        # (server delays 0.1s, sends chunk, waits 0.1s, sends chunk)
+        assert (
+            0.15 < second_chunk_time < 0.4
+        ), f"Second chunk timing unexpected: {second_chunk_time:.3f}s (expected ~0.2s)"
+        
+        # The gap between chunks should be around 0.1s
+        chunk_gap = second_chunk_time - first_chunk_time
+        assert (
+            0.05 < chunk_gap < 0.25
+        ), f"Chunk gap unexpected: {chunk_gap:.3f}s (expected ~0.1s)"

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -260,8 +260,8 @@ async def test_streaming_chunk_timing(slow_server):
     
     This test verifies that we can:
     1. Receive the response immediately
-    2. Receive the first chunk about 0.1 seconds later
-    3. Receive the second chunk about 0.1 seconds later
+    2. Receive the first chunk about 0.01 seconds later
+    3. Receive the second chunk about 0.01 seconds later
     
     This tests whether the transport supports true streaming (returning
     early from perform()) rather than buffering all data.
@@ -297,25 +297,25 @@ async def test_streaming_chunk_timing(slow_server):
         print(f"First chunk received after: {chunk_times[0][0]:.3f}s")
         print(f"Second chunk received after: {chunk_times[1][0]:.3f}s")
         
-        # Verify timing: chunks should arrive approximately 0.1s apart
+        # Verify timing: chunks should arrive approximately 0.01s apart
         # with some tolerance for timing variations
         first_chunk_time = chunk_times[0][0]
         second_chunk_time = chunk_times[1][0]
         
-        # First chunk should arrive around 0.1s after response
-        # (server delays 0.1s before sending first chunk)
+        # First chunk should arrive around 0.01s after response
+        # (server delays 0.01s before sending first chunk)
         assert (
-            0.05 < first_chunk_time < 0.3
-        ), f"First chunk timing unexpected: {first_chunk_time:.3f}s (expected ~0.1s)"
+            0.005 < first_chunk_time < 0.03
+        ), f"First chunk timing unexpected: {first_chunk_time:.3f}s (expected ~0.01s)"
         
-        # Second chunk should arrive around 0.2s total
-        # (server delays 0.1s, sends chunk, waits 0.1s, sends chunk)
+        # Second chunk should arrive around 0.02s total
+        # (server delays 0.01s, sends chunk, waits 0.01s, sends chunk)
         assert (
-            0.15 < second_chunk_time < 0.4
-        ), f"Second chunk timing unexpected: {second_chunk_time:.3f}s (expected ~0.2s)"
+            0.015 < second_chunk_time < 0.04
+        ), f"Second chunk timing unexpected: {second_chunk_time:.3f}s (expected ~0.02s)"
         
-        # The gap between chunks should be around 0.1s
+        # The gap between chunks should be around 0.01s
         chunk_gap = second_chunk_time - first_chunk_time
         assert (
-            0.05 < chunk_gap < 0.25
-        ), f"Chunk gap unexpected: {chunk_gap:.3f}s (expected ~0.1s)"
+            0.005 < chunk_gap < 0.025
+        ), f"Chunk gap unexpected: {chunk_gap:.3f}s (expected ~0.01s)"

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -11,7 +11,7 @@ from httpx_pycurl import transport
 
 @pytest.mark.asyncio
 async def test_async_multi_socket_transport(ca_cert, server):
-    async with transport.AsyncPyCurlTransport(cainfo=ca_cert) as tx:
+    async with transport.AsyncPyCurlTransport(cainfo=ca_cert, timeout=2) as tx:
         request = httpx.Request("GET", server)
 
         response = await tx.handle_async_request(request)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -10,11 +10,9 @@ from httpx_pycurl import transport
 
 
 @pytest.mark.asyncio
-async def test_async_multi_socket_transport(monkeypatch: pytest.MonkeyPatch):
-    # logging.basicConfig(level=logging.DEBUG)
-
-    async with transport.AsyncPyCurlTransport() as tx:
-        request = httpx.Request("GET", "http://www.example.com/")
+async def test_async_multi_socket_transport(ca_cert, server):
+    async with transport.AsyncPyCurlTransport(cainfo=ca_cert) as tx:
+        request = httpx.Request("GET", server)
 
         response = await tx.handle_async_request(request)
 
@@ -257,65 +255,63 @@ async def test_response_closed_early(regular, short_server):
 @pytest.mark.asyncio
 async def test_streaming_chunk_timing(slow_server):
     """Test that streaming chunks are received at the expected times.
-    
+
     This test verifies that we can:
     1. Receive the response immediately
     2. Receive the first chunk about 0.01 seconds later
     3. Receive the second chunk about 0.01 seconds later
-    
+
     This tests whether the transport supports true streaming (returning
     early from perform()) rather than buffering all data.
     """
     url = f"{slow_server}stream"
-    
-    async with httpx.AsyncClient(
-        transport=transport.AsyncPyCurlTransport()
-    ) as client:
+
+    async with httpx.AsyncClient(transport=transport.AsyncPyCurlTransport()) as client:
         # Record when we start
         response_received_time = None
         chunk_times = []
-        
+
         # Start streaming
         start_time = time.monotonic()
         async with client.stream("GET", url) as response:
             # Record when response headers are received
             response_received_time = time.monotonic() - start_time
             assert response.status_code == 200
-            
+
             # Iterate through chunks and record timing
             async for chunk in response.aiter_bytes():
                 chunk_time = time.monotonic() - start_time
                 chunk_times.append((chunk_time, chunk))
-        
+
         # Verify we got exactly 2 chunks, each containing b"OK\n"
         assert len(chunk_times) == 2, f"Expected 2 chunks, got {len(chunk_times)}"
         assert chunk_times[0][1] == b"OK\n", f"First chunk: {chunk_times[0][1]}"
         assert chunk_times[1][1] == b"OK\n", f"Second chunk: {chunk_times[1][1]}"
-        
+
         # Print timing information
         print(f"\nResponse received after: {response_received_time:.3f}s")
         print(f"First chunk received after: {chunk_times[0][0]:.3f}s")
         print(f"Second chunk received after: {chunk_times[1][0]:.3f}s")
-        
+
         # Verify timing: chunks should arrive approximately 0.01s apart
         # with some tolerance for timing variations
         first_chunk_time = chunk_times[0][0]
         second_chunk_time = chunk_times[1][0]
-        
+
         # First chunk should arrive around 0.01s after response
         # (server delays 0.01s before sending first chunk)
-        assert (
-            0.005 < first_chunk_time < 0.03
-        ), f"First chunk timing unexpected: {first_chunk_time:.3f}s (expected ~0.01s)"
-        
+        assert 0.005 < first_chunk_time < 0.03, (
+            f"First chunk timing unexpected: {first_chunk_time:.3f}s (expected ~0.01s)"
+        )
+
         # Second chunk should arrive around 0.02s total
         # (server delays 0.01s, sends chunk, waits 0.01s, sends chunk)
-        assert (
-            0.015 < second_chunk_time < 0.04
-        ), f"Second chunk timing unexpected: {second_chunk_time:.3f}s (expected ~0.02s)"
-        
+        assert 0.015 < second_chunk_time < 0.04, (
+            f"Second chunk timing unexpected: {second_chunk_time:.3f}s (expected ~0.02s)"
+        )
+
         # The gap between chunks should be around 0.01s
         chunk_gap = second_chunk_time - first_chunk_time
-        assert (
-            0.005 < chunk_gap < 0.025
-        ), f"Chunk gap unexpected: {chunk_gap:.3f}s (expected ~0.01s)"
+        assert 0.005 < chunk_gap < 0.025, (
+            f"Chunk gap unexpected: {chunk_gap:.3f}s (expected ~0.01s)"
+        )


### PR DESCRIPTION
Client is able to get headers, wait, get a line of the response, wait, and get another line of response.

Fix #11