### PR TITLE
Improve cleanup on .close(); bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.0.6
+
+- Improve cleanup on `CurlMulti.close()`; `AsyncCurl()` now avoids calling
+  `CurlMulti()` methods during or after its `.close()` call.
+
 # 0.0.5
 
 - Implement true streaming responses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "httpx-pycurl"
-version = "0.0.5"
+version = "0.0.6"
 description = "An httpx transport powered by pycurl"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/httpx_pycurl/curl.py
+++ b/src/httpx_pycurl/curl.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 
 import pycurl
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -153,7 +153,7 @@ class AsyncCurl:
             try:
                 self._multi.close()
             except Exception as e:
-                logger.exception("Error closing CurlMulti: %s", e)
+                log.exception("Error closing CurlMulti: %s", e)
             self._multi = None
 
         self._transfers.clear()
@@ -205,7 +205,7 @@ class AsyncCurl:
             if what in {pycurl.POLL_OUT, pycurl.POLL_INOUT}:
                 self._loop.add_writer(fd, self._on_socket_writable, fd)
         except (OSError, ValueError, RuntimeError) as e:
-            logger.warning("Failed to register socket %d: %s", fd, e)
+            log.warning("Failed to register socket %d: %s", fd, e)
             self._socket_watch.pop(fd, None)
             try:
                 self._loop.remove_reader(fd)
@@ -226,7 +226,7 @@ class AsyncCurl:
     def _timer_callback(self, timeout_ms: int) -> int:
         """Called by libcurl to schedule next timeout."""
         if self._closed:
-            logger.debug("_timer_callback(timeout_ms=%s) after close.", timeout_ms)
+            log.debug("_timer_callback(timeout_ms=%s) after close.", timeout_ms)
         self._schedule_timeout(timeout_ms)
         return 0
 
@@ -280,7 +280,7 @@ class AsyncCurl:
         if self._closed:
             # normal on shutdown, ignore; curl cleans its own fd's.
             # .socket_action() can no longer succeed.
-            logger.debug(
+            log.debug(
                 "_drive_socket(sock_fd=%s, event_mask=%s) after close",
                 sock_fd,
                 event_mask,
@@ -331,4 +331,4 @@ class AsyncCurl:
         try:
             self._multi.remove_handle(curl)
         except Exception as e:
-            logger.warning("Error removing handle from multi: %s", e)
+            log.warning("Error removing handle from multi: %s", e)

--- a/src/httpx_pycurl/curl.py
+++ b/src/httpx_pycurl/curl.py
@@ -263,14 +263,10 @@ class AsyncCurl:
 
     def _on_socket_readable(self, fd: int) -> None:
         """Called when socket is readable."""
-        if self._closed:
-            logger.debug("_on_socket_readable(%s) after close", fd)
-            return
         self._drive_socket(fd, pycurl.CSELECT_IN)
 
     def _on_socket_writable(self, fd: int) -> None:
         """Called when socket is writable."""
-
         self._drive_socket(fd, pycurl.CSELECT_OUT)
 
     def _on_timeout(self) -> None:

--- a/src/httpx_pycurl/curl.py
+++ b/src/httpx_pycurl/curl.py
@@ -225,6 +225,8 @@ class AsyncCurl:
 
     def _timer_callback(self, timeout_ms: int) -> int:
         """Called by libcurl to schedule next timeout."""
+        if self._closed:
+            logger.debug("_timer_callback(timeout_ms=%s) after close.", timeout_ms)
         self._schedule_timeout(timeout_ms)
         return 0
 
@@ -261,10 +263,14 @@ class AsyncCurl:
 
     def _on_socket_readable(self, fd: int) -> None:
         """Called when socket is readable."""
+        if self._closed:
+            logger.debug("_on_socket_readable(%s) after close", fd)
+            return
         self._drive_socket(fd, pycurl.CSELECT_IN)
 
     def _on_socket_writable(self, fd: int) -> None:
         """Called when socket is writable."""
+
         self._drive_socket(fd, pycurl.CSELECT_OUT)
 
     def _on_timeout(self) -> None:
@@ -275,6 +281,16 @@ class AsyncCurl:
     def _drive_socket(self, sock_fd: int, event_mask: int) -> None:
         """Process socket activity in the multi handle."""
         # Call socket_action until no more immediate work
+        if self._closed:
+            # normal on shutdown, ignore; curl cleans its own fd's.
+            # .socket_action() can no longer succeed.
+            logger.debug(
+                "_drive_socket(sock_fd=%s, event_mask=%s) after close",
+                sock_fd,
+                event_mask,
+            )
+            return
+
         while True:
             status, _running = self._multi.socket_action(sock_fd, event_mask)
             if status != pycurl.E_CALL_MULTI_PERFORM:


### PR DESCRIPTION
curl can send us some or dozens of callbacks during the `multi.close()` call, to remind us to stop monitoring file handles; in the meantime, libcurl should synchronously close any remaining connections. The callbacks would trigger failed `drive_socket()` calls to a closed multi handle. Instead, ignore `drive_socket()` during or after `AsyncCurl.aclose()`.